### PR TITLE
feat: Micrometer-Prometheus 레지스트리 추가 및 Actuator 엔드포인트 확장 설정

### DIFF
--- a/GatewayService/build.gradle
+++ b/GatewayService/build.gradle
@@ -36,8 +36,11 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-    // Spring Boot Actuator (Health Check용)
+    // Spring Boot Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // Micrometer-Registry
+    implementation 'io.micrometer:micrometer-registry-prometheus'
 
     // eureka client
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway'

--- a/GatewayService/src/main/java/ready_to_marry/gatewayservice/common/dto/JwtClaims.java
+++ b/GatewayService/src/main/java/ready_to_marry/gatewayservice/common/dto/JwtClaims.java
@@ -20,5 +20,7 @@ public class JwtClaims {
     // 관리자(ADMIN)일 때만 사용
     private Long adminId;
     private String adminRole;
+
+    private String accountId;
 }
 

--- a/GatewayService/src/main/java/ready_to_marry/gatewayservice/common/dto/JwtClaims.java
+++ b/GatewayService/src/main/java/ready_to_marry/gatewayservice/common/dto/JwtClaims.java
@@ -18,8 +18,7 @@ public class JwtClaims {
     private Long partnerId;
 
     // 관리자(ADMIN)일 때만 사용
+    private Long adminId;
     private String adminRole;
-
-    private String accountId;
 }
 

--- a/GatewayService/src/main/java/ready_to_marry/gatewayservice/config/CorsConfig.java
+++ b/GatewayService/src/main/java/ready_to_marry/gatewayservice/config/CorsConfig.java
@@ -11,7 +11,7 @@ public class CorsConfig {
     @Bean
     public CorsWebFilter corsFilter() {
         CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("http://localhost:3000"); // React 개발 서버 주소
+        config.addAllowedOriginPattern("*"); // React 개발 서버 주소
         config.addAllowedMethod("*");
         config.addAllowedHeader("*");
         config.setAllowCredentials(true);

--- a/GatewayService/src/main/java/ready_to_marry/gatewayservice/filter/JwtAuthenticationFilter.java
+++ b/GatewayService/src/main/java/ready_to_marry/gatewayservice/filter/JwtAuthenticationFilter.java
@@ -57,31 +57,27 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
             switch (claims.getRole()) {
                 case "ADMIN":
                     mutatedRequestBuilder
-                            .header("X-Account-Id", claims.getAccountId())
-                            .header("X-Admin-Id", String.valueOf(claims.getAccountId()))
+                            .header("X-Admin-Id", String.valueOf(claims.getAdminId()))
                             .header("X-Admin-Role", claims.getAdminRole())
-                            .header("X-Role", claims.getAdminRole());
+                            .header("X-Role", claims.getRole());
                     System.out.println(claims.getAdminRole());
-                    System.out.println("admin id"+String.valueOf(claims.getAccountId()));
-                    System.out.println(claims.getAccountId());
-                    System.out.println(claims.getAdminRole());
+                    System.out.println(claims.getAdminId());
+                    System.out.println(claims.getRole());
                     break;
                 case "PARTNER":
                     mutatedRequestBuilder
-                            .header("X-Account-Id", claims.getAccountId())
                             .header("X-Partner-Id", String.valueOf(claims.getPartnerId()))
                             .header("X-Role", claims.getRole());
-                    System.out.println(claims.getRole());
                     System.out.println(claims.getPartnerId());
+                    System.out.println(claims.getRole());
                     break;
                 case "USER":
                 default:
                     mutatedRequestBuilder
-                            .header("X-Account-Id", claims.getAccountId())
                             .header("X-User-Id", String.valueOf(claims.getUserId()))
                             .header("X-Role", claims.getRole());
-                    System.out.println(claims.getRole());
                     System.out.println(claims.getUserId());
+                    System.out.println(claims.getRole());
                     break;
             }
 

--- a/GatewayService/src/main/java/ready_to_marry/gatewayservice/filter/JwtAuthenticationFilter.java
+++ b/GatewayService/src/main/java/ready_to_marry/gatewayservice/filter/JwtAuthenticationFilter.java
@@ -57,25 +57,31 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
             switch (claims.getRole()) {
                 case "ADMIN":
                     mutatedRequestBuilder
+                            .header("X-Account-Id", claims.getAccountId())
                             .header("X-Admin-Id", String.valueOf(claims.getAdminId()))
                             .header("X-Admin-Role", claims.getAdminRole())
                             .header("X-Role", claims.getRole());
+                    System.out.println(claims.getAccountId());
                     System.out.println(claims.getAdminRole());
                     System.out.println(claims.getAdminId());
                     System.out.println(claims.getRole());
                     break;
                 case "PARTNER":
                     mutatedRequestBuilder
+                            .header("X-Account-Id", claims.getAccountId())
                             .header("X-Partner-Id", String.valueOf(claims.getPartnerId()))
                             .header("X-Role", claims.getRole());
+                    System.out.println(claims.getAccountId());
                     System.out.println(claims.getPartnerId());
                     System.out.println(claims.getRole());
                     break;
                 case "USER":
                 default:
                     mutatedRequestBuilder
+                            .header("X-Account-Id", claims.getAccountId())
                             .header("X-User-Id", String.valueOf(claims.getUserId()))
                             .header("X-Role", claims.getRole());
+                    System.out.println(claims.getAccountId());
                     System.out.println(claims.getUserId());
                     System.out.println(claims.getRole());
                     break;

--- a/GatewayService/src/main/java/ready_to_marry/gatewayservice/util/JwtUtil.java
+++ b/GatewayService/src/main/java/ready_to_marry/gatewayservice/util/JwtUtil.java
@@ -48,7 +48,6 @@ public class JwtUtil {
                 .userId(claims.get("userId", Long.class))
                 .partnerId(claims.get("partnerId", Long.class))
                 .adminRole(claims.get("adminRole", String.class))
-                .accountId(claims.getSubject())
                 .build();
     }
 }

--- a/GatewayService/src/main/java/ready_to_marry/gatewayservice/util/JwtUtil.java
+++ b/GatewayService/src/main/java/ready_to_marry/gatewayservice/util/JwtUtil.java
@@ -47,6 +47,7 @@ public class JwtUtil {
                 .role(claims.get("role", String.class))
                 .userId(claims.get("userId", Long.class))
                 .partnerId(claims.get("partnerId", Long.class))
+                .adminId(claims.get("adminId", Long.class))
                 .adminRole(claims.get("adminRole", String.class))
                 .build();
     }

--- a/GatewayService/src/main/java/ready_to_marry/gatewayservice/util/JwtUtil.java
+++ b/GatewayService/src/main/java/ready_to_marry/gatewayservice/util/JwtUtil.java
@@ -49,6 +49,7 @@ public class JwtUtil {
                 .partnerId(claims.get("partnerId", Long.class))
                 .adminId(claims.get("adminId", Long.class))
                 .adminRole(claims.get("adminRole", String.class))
+                .accountId(claims.getSubject())
                 .build();
     }
 }

--- a/GatewayService/src/main/resources/application.properties
+++ b/GatewayService/src/main/resources/application.properties
@@ -25,8 +25,7 @@ jwt.skip-paths[6]=/auth/partners/verify/result
 jwt.skip-paths[7]=/auth/admins/login
 jwt.skip-paths[8]=/auth/token/refresh
 jwt.skip-paths[9]=/partners/profile
-jwt.skip-paths[10]=/partner-service
-jwt.skip-paths[11]=/actuator/health
+jwt.skip-paths[10]=/actuator/health
 
 
 # Gateway ??? ??

--- a/GatewayService/src/main/resources/application.properties
+++ b/GatewayService/src/main/resources/application.properties
@@ -14,7 +14,7 @@ eureka.instance.prefer-ip-address=${EUREKA_INSTANCE_PREFER_IP_ADDRESS}
 spring.cloud.gateway.discovery.locator.enabled=true
 
 #Jwt Secret
-jwt.secret-key=${JWT_SECERT_KEY}
+jwt.secret-key=${JWT_SECRET_KEY}
 jwt.skip-paths[0]=/auth/oauth2/authorize
 jwt.skip-paths[1]=/auth/oauth2/callback
 jwt.skip-paths[2]=/auth/users/profile/complete

--- a/GatewayService/src/main/resources/application.properties
+++ b/GatewayService/src/main/resources/application.properties
@@ -1,7 +1,10 @@
 server.port = 8089
 
-#  /actuator/health ??
-management.endpoints.web.exposure.include=health
+# /actuator
+management.endpoints.web.exposure.include=health,info,metrics,prometheus
+management.endpoint.prometheus.enabled=true
+management.endpoints.web.base-path=/actuator
+management.prometheus.metrics.export.enabled=true
 
 # Eureka ??
 spring.application.name=gateway-service

--- a/GatewayService/src/main/resources/application.properties
+++ b/GatewayService/src/main/resources/application.properties
@@ -26,6 +26,7 @@ jwt.skip-paths[7]=/auth/admins/login
 jwt.skip-paths[8]=/auth/token/refresh
 jwt.skip-paths[9]=/partners/profile
 jwt.skip-paths[10]=/actuator/health
+jwt.skip-paths[11]=/payment-service/payment/verify
 
 
 # Gateway ??? ??


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- Micrometer-Prometheus 레지스트리를 도입하고, Actuator 엔드포인트 노출 범위를 헬스체크뿐 아니라 정보·메트릭·Prometheus 스크랩용까지 확장했습니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- build.gradle
   - io.micrometer:micrometer-registry-prometheus 의존성 추가

- application.properties
   - management.endpoints.web.exposure.include 설정을 health → health,info,metrics,prometheus로 변경
   - management.endpoint.prometheus.enabled=true로 Prometheus 스크랩 엔드포인트 활성화
   - management.endpoints.web.base-path=/actuator 지정
   - management.prometheus.metrics.export.enabled=true로 Micrometer → Prometheus 내보내기 활성화

## 📸 스크린샷 (Optional)

## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
