### PR TITLE
Feat/jwt skip actuator endpoints: JWT 스킵 경로에 Actuator 엔드포인트 추가

### DIFF
--- a/GatewayService/src/main/resources/application.properties
+++ b/GatewayService/src/main/resources/application.properties
@@ -30,7 +30,9 @@ jwt.skip-paths[8]=/auth/token/refresh
 jwt.skip-paths[9]=/partners/profile
 jwt.skip-paths[10]=/partner-service
 jwt.skip-paths[11]=/actuator/health
-
+jwt.skip-paths[12]=/actuator/prometheus
+jwt.skip-paths[13]=/actuator/info
+jwt.skip-paths[14]=/actuator/metrics
 
 # Gateway ??? ??
 spring.cloud.gateway.routes[0].id=user-service


### PR DESCRIPTION
## 🔥 개요 (Purpose)
- JWT 인증 필터를 적용하지 않을 Actuator 엔드포인트(/prometheus, /info, /metrics)를 스킵 경로에 추가합니다.

## ✅ 작업 내용 (Changes)
- [x] 기능 추가 / 수정
- [ ] 버그 수정
- [ ] 코드 리팩토링
- [ ] 문서 작성
- [ ] 테스트 추가

## 📝 상세 내용 (Details)
- application.properties
   - /actuator/prometheus, /actuator/info, /actuator/metrics 엔드포인트 접근 시 JWT 인증을 건너뛰도록 구성

## 📸 스크린샷 (Optional)
 
## 🔗 관련 이슈 (Linked Issue)

## 📌 참고 사항 (Additional Notes)
